### PR TITLE
Make finc select's usagePermitted filter more intuitive

### DIFF
--- a/src/main/java/org/folio/finc/select/query/MetadataSourcesQueryTranslator.java
+++ b/src/main/java/org/folio/finc/select/query/MetadataSourcesQueryTranslator.java
@@ -11,8 +11,7 @@ public class MetadataSourcesQueryTranslator extends QueryTranslator {
       String query,
       String key,
       String isil,
-      UnaryOperator<String> replaceQueryFunc,
-      UnaryOperator<String> postProcessQueryFunc) {
+      UnaryOperator<String> replaceQueryFunc) {
 
     query = prepareQuery(query);
 

--- a/src/test/java/org/folio/finc/select/MetadataCollectionsQueryTranslatorTest.java
+++ b/src/test/java/org/folio/finc/select/MetadataCollectionsQueryTranslatorTest.java
@@ -24,7 +24,8 @@ public class MetadataCollectionsQueryTranslatorTest {
   public void translatePermittedFalse() {
     String query = "mdSource.id=\"uuid-1234\" AND permitted=no";
     String expected =
-        "(mdSource.id=\"uuid-1234\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"" + isil + "\")";
+        "(mdSource.id=\"uuid-1234\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \""
+            + isil + "\" AND usageRestricted=\"yes\")";
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
     assertEquals(expected, result);
@@ -46,7 +47,8 @@ public class MetadataCollectionsQueryTranslatorTest {
   public void translatePermittedFalseWithoutSource() {
     String query = "permitted=no";
     String expected =
-        "(cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"" + isil + "\")";
+        "(cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"" + isil
+            + "\" AND usageRestricted=\"yes\")";
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
     assertEquals(expected, result);
@@ -110,7 +112,7 @@ public class MetadataCollectionsQueryTranslatorTest {
     String query = "mdSource.id=\"uuid-1234\" AND selected=no AND permitted=no";
     String expected =
         String.format(
-            "(mdSource.id=\"uuid-1234\") AND (cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"%s\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"%s\")",
+            "(mdSource.id=\"uuid-1234\") AND (cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"%s\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"%s\" AND usageRestricted=\"yes\")",
             isil, isil);
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
@@ -134,7 +136,7 @@ public class MetadataCollectionsQueryTranslatorTest {
     String query = "selected=no AND permitted=no";
     String expected =
         String.format(
-            "(cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"%s\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"%s\")",
+            "(cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"%s\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"%s\" AND usageRestricted=\"yes\")",
             isil, isil);
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
@@ -199,7 +201,7 @@ public class MetadataCollectionsQueryTranslatorTest {
             + isil
             + "\" OR usageRestricted=\"no\") OR (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \""
             + isil
-            + "\"))";
+            + "\" AND usageRestricted=\"yes\"))";
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
     assertEquals(expected, result);
@@ -211,7 +213,7 @@ public class MetadataCollectionsQueryTranslatorTest {
     String expected =
         "((cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \""
             + isil
-            + "\") OR (permittedFor =/respectCase/respectAccents \""
+            + "\" AND usageRestricted=\"yes\") OR (permittedFor =/respectCase/respectAccents \""
             + isil
             + "\" OR usageRestricted=\"no\"))";
     String result = cut.translateQuery(query, isil);
@@ -230,7 +232,7 @@ public class MetadataCollectionsQueryTranslatorTest {
             + "\")) AND "
             + "((cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \""
             + isil
-            + "\") OR (permittedFor =/respectCase/respectAccents \""
+            + "\" AND usageRestricted=\"yes\") OR (permittedFor =/respectCase/respectAccents \""
             + isil
             + "\" OR usageRestricted=\"no\"))";
 
@@ -252,7 +254,7 @@ public class MetadataCollectionsQueryTranslatorTest {
             + "\")) AND "
             + "((cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \""
             + isil
-            + "\") OR (permittedFor =/respectCase/respectAccents \""
+            + "\" AND usageRestricted=\"yes\") OR (permittedFor =/respectCase/respectAccents \""
             + isil
             + "\" OR usageRestricted=\"no\"))";
     String result = cut.translateQuery(query, isil);
@@ -273,7 +275,7 @@ public class MetadataCollectionsQueryTranslatorTest {
             + "\")) AND "
             + "((cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \""
             + isil
-            + "\") OR (permittedFor =/respectCase/respectAccents \""
+            + "\" AND usageRestricted=\"yes\") OR (permittedFor =/respectCase/respectAccents \""
             + isil
             + "\" OR usageRestricted=\"no\"))";
     String result = cut.translateQuery(query, isil);
@@ -292,7 +294,7 @@ public class MetadataCollectionsQueryTranslatorTest {
             + isil
             + "\" OR usageRestricted=\"no\") OR (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \""
             + isil
-            + "\"))";
+            + "\" AND usageRestricted=\"yes\"))";
 
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
@@ -305,7 +307,7 @@ public class MetadataCollectionsQueryTranslatorTest {
     String expected =
         "(cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \""
             + isil
-            + "\") sortby label/sort.descending";
+            + "\" AND usageRestricted=\"yes\") sortby label/sort.descending";
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
     assertEquals(expected, result);
@@ -316,7 +318,7 @@ public class MetadataCollectionsQueryTranslatorTest {
     String query =
         "(selected=\"no\" and permitted=\"no\" and freeContent=(\"yes\" or \"undetermined\"))";
     String expected =
-        "(freeContent=(\"yes\" or \"undetermined\")) AND (cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"ISIL-01\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"ISIL-01\")";
+        "(freeContent=(\"yes\" or \"undetermined\")) AND (cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"ISIL-01\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"ISIL-01\" AND usageRestricted=\"yes\")";
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
     assertEquals(expected, result);
@@ -327,7 +329,7 @@ public class MetadataCollectionsQueryTranslatorTest {
     String query =
         "(freeContent=(\"yes\" or \"undetermined\") and selected=\"no\" and permitted=\"no\")";
     String expected =
-        "(freeContent=(\"yes\" or \"undetermined\")) AND (cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"ISIL-01\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"ISIL-01\")";
+        "(freeContent=(\"yes\" or \"undetermined\")) AND (cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"ISIL-01\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"ISIL-01\" AND usageRestricted=\"yes\")";
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
     assertEquals(expected, result);
@@ -338,7 +340,7 @@ public class MetadataCollectionsQueryTranslatorTest {
     String query =
         "(selected=\"no\" and freeContent=(\"yes\" or \"undetermined\") and permitted=\"no\")";
     String expected =
-        "(freeContent=(\"yes\" or \"undetermined\")) AND (cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"ISIL-01\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"ISIL-01\")";
+        "(freeContent=(\"yes\" or \"undetermined\")) AND (cql.allRecords=1 NOT selectedBy =/respectCase/respectAccents \"ISIL-01\") AND (cql.allRecords=1 NOT permittedFor =/respectCase/respectAccents \"ISIL-01\" AND usageRestricted=\"yes\")";
     String result = cut.translateQuery(query, isil);
     assertNotNull(result);
     assertEquals(expected, result);


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODGOBI-43 Move "Renewals" information to Purchase Order level

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
When querying finc-select's metadata collections for usagePermitted=no "AND usageRestricted=yes" is appended to the query. Now, only metadata collections which cannot be selected by the user/tenant are returned.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODGOBI-43
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Query is preprocessed to translate tenant identifier together with selected query (e.g. permitted) to corresponding ISIL. 

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
