### PR TITLE
Add finc-config endpoints for files and filters

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -165,6 +165,54 @@
       ]
     },
     {
+      "id": "finc-config/filters",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/finc-config/filters",
+          "permissionsRequired": [
+            "finc-config.filters.collection.get"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/finc-config/filters/{id}",
+          "permissionsRequired": [
+            "finc-config.filters.item.get"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/finc-config/filters/{id}/collections",
+          "permissionsRequired": [
+            "finc-config.filters.item.get"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "finc-config/files",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/finc-config/files/{id}",
+          "permissionsRequired": [
+            "finc-config.files.item.get"
+          ]
+        }
+      ]
+    },
+    {
       "id": "finc-select/metadata-collections",
       "version": "1.0",
       "handlers": [
@@ -476,6 +524,21 @@
       "description": "Finc config: Delete an isil"
     },
     {
+      "permissionName": "finc-config.filters.collection.get",
+      "displayName": "finc config filters collection get",
+      "description": "Finc config: Get collection of filters"
+    },
+    {
+      "permissionName": "finc-config.filters.item.get",
+      "displayName": "finc config filters item get",
+      "description": "Finc config: Get a single filter"
+    },
+    {
+      "permissionName": "finc-config.files.item.get",
+      "displayName": "finc config files item get",
+      "description": "Finc config: Get a single file"
+    },
+    {
       "permissionName": "finc-select.metadata-collections.collection.get",
       "displayName": "finc select metadata collections collection get",
       "description": "Finc select: Get a collection of metadata collections"
@@ -589,7 +652,10 @@
         "finc-config.isils.item.get",
         "finc-config.isils.item.post",
         "finc-config.isils.item.put",
-        "finc-config.isils.item.delete"
+        "finc-config.isils.item.delete",
+        "finc-config.filters.collection.get",
+        "finc-config.filters.item.get",
+        "finc-config.files.item.get"
       ],
       "visible": true
     },

--- a/ramls/examples/fincSelectFilter1.sample
+++ b/ramls/examples/fincSelectFilter1.sample
@@ -1,4 +1,5 @@
 {
+  "id": "084befb6-a264-4dd0-ade9-1aaae390c483",
   "label": "Holdings 1",
   "type": "Whitelist",
   "filterFiles": [
@@ -8,5 +9,6 @@
       "filename": "filterFile.txt",
       "fileId": "aa9202b7-754a-414a-8bf6-378df78e5985"
     }
-  ]
+  ],
+  "isil": "DE-15"
 }

--- a/ramls/examples/fincSelectFilter2.sample
+++ b/ramls/examples/fincSelectFilter2.sample
@@ -1,4 +1,6 @@
 {
+  "id": "084befb6-a264-4dd0-ade9-1aaae390c484",
   "label": "Holdings 2",
-  "type": "Blacklist"
+  "type": "Blacklist",
+  "isil": "DE-15"
 }

--- a/ramls/examples/fincSelectFilterToMetadataCollections.sample
+++ b/ramls/examples/fincSelectFilterToMetadataCollections.sample
@@ -1,8 +1,10 @@
 {
+  "id": "6dd325f8-b1d5-4568-a0d7-aecf6b8d6123",
   "collectionIds": [
     "4c890350-4ddf-4851-ae2b-e4403eacca08",
     "4c890350-4ddf-4851-ae2b-e4403eacca09",
     "4c890350-4ddf-4851-ae2b-e4403eacca07"
   ],
+  "isil": "DE-15",
   "collectionsCount": 3
 }

--- a/ramls/examples/fincSelectFilter_collection.sample
+++ b/ramls/examples/fincSelectFilter_collection.sample
@@ -1,6 +1,7 @@
 {
   "fincSelectFilters": [
     {
+      "id": "084befb6-a264-4dd0-ade9-1aaae390c483",
       "label": "Holdings 1",
       "type": "Whitelist",
       "filterFiles": [
@@ -10,7 +11,8 @@
           "filename": "filterFile.txt",
           "fileId": "aa9202b7-754a-414a-8bf6-378df78e5985"
         }
-      ]
+      ],
+      "isil": "DE-15"
     }
   ],
   "totalRecords": 1

--- a/ramls/fincConfigFiles.raml
+++ b/ramls/fincConfigFiles.raml
@@ -1,0 +1,34 @@
+#%RAML 1.0
+title: Files for Finc Config
+version: v1
+baseUri: http://localhost/mod-finc-config
+
+documentation:
+  - title: mod-finc-config API
+    content: This documents the API calls that can be made to query files
+
+traits:
+  orderable: !include ./raml-util/traits/orderable.raml
+  pageable: !include ./raml-util/traits/pageable.raml
+  searchable: !include ./raml-util/traits/searchable.raml
+  language: !include ./raml-util/traits/language.raml
+
+resourceTypes:
+  collection-item: !include ./raml-util/rtypes/item-collection.raml
+
+/finc-config/files:
+  displayName: Finc config files
+  /{id}:
+    get:
+      description: Get file by id
+      responses:
+        200:
+          body:
+            application/octet-stream:
+        404:
+          body:
+            text/plain:
+        500:
+          description: Server Error
+          body:
+            text/plain:

--- a/ramls/fincConfigFilters.raml
+++ b/ramls/fincConfigFilters.raml
@@ -1,0 +1,74 @@
+#%RAML 1.0
+title: Filters for Finc Config
+version: v1
+baseUri: http://localhost/mod-finc-config
+
+documentation:
+  - title: mod-finc-config API
+    content: This documents the API calls that can be made to query filters of metadata collections
+
+types:
+  fincSelectFilter: !include schemas/fincSelectFilter.json
+  fincSelectFilters: !include schemas/fincSelectFilters.json
+  fincSelectFilterToCollections: !include schemas/fincSelectFilterToCollections.json
+  errors: !include ./raml-util/schemas/errors.schema
+
+traits:
+  orderable: !include ./raml-util/traits/orderable.raml
+  pageable: !include ./raml-util/traits/pageable.raml
+  searchable: !include ./raml-util/traits/searchable.raml
+  language: !include ./raml-util/traits/language.raml
+  validate: !include ./raml-util/traits/validation.raml
+
+resourceTypes:
+  collection: !include ./raml-util/rtypes/collection.raml
+  collection-item: !include ./raml-util/rtypes/item-collection.raml
+
+/finc-config/filters:
+  displayName: Finc config filters
+  type:
+    collection:
+      exampleCollection: !include examples/fincSelectFilter_collection.sample
+      exampleItem: !include examples/fincSelectFilter1.sample
+      schemaCollection: fincSelectFilters
+      schemaItem: fincSelectFilter
+  get:
+    is: [
+      searchable: {description: "", example: "((label=\"test*\") and type=\"Blacklist\") sortby label"},
+      orderable: {fieldsList: "label, type"},
+      pageable
+    ]
+    description: Get all filters
+  post:
+    description: Not implemented.
+  /{id}:
+    type:
+      collection-item:
+        exampleItem: !include examples/fincSelectFilter1.sample
+        schema: fincSelectFilter
+    get:
+      description: Get one finc select filter identified by id
+    put:
+      description: Not implemented.
+    delete:
+      description: Not implemented.
+    /collections:
+      get:
+        description: Get collections the current filter is assigned to
+        responses:
+          200:
+            description: The collection IDs of collection assigned to this filter
+            body:
+              application/json:
+                type: fincSelectFilterToCollections
+                example: !include examples/fincSelectFilterToMetadataCollections.sample
+          404:
+            description: Not found
+            body:
+              text/plain:
+                example: Not found
+          500:
+            description: Internal server error
+            body:
+              text/plain:
+                example: "Internal server error"

--- a/src/main/java/org/folio/finc/dao/FileDAO.java
+++ b/src/main/java/org/folio/finc/dao/FileDAO.java
@@ -7,8 +7,6 @@ import org.folio.rest.persist.Criteria.Criterion;
 
 public interface FileDAO {
 
-  String TABLE_NAME = "files";
-
   Future<File> getById(String id, Context vertxContext);
 
   Future<File> getByCriterion(Criterion criterion, Context vertxContext);

--- a/src/main/java/org/folio/finc/dao/FileDAO.java
+++ b/src/main/java/org/folio/finc/dao/FileDAO.java
@@ -3,12 +3,14 @@ package org.folio.finc.dao;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import org.folio.finc.model.File;
+import org.folio.rest.persist.Criteria.Criterion;
 
 public interface FileDAO {
 
-  Future<File> getById(String id, String isil, Context vertxContext);
+  String TABLE_NAME = "files";
 
-  Future<File> upsert(File entity, String id, Context vertxContext);
+  Future<File> getById(String id, Context vertxContext);
 
-  Future<Integer> deleteById(String id, String isil, Context vertxContext);
+  Future<File> getByCriterion(Criterion criterion, Context vertxContext);
+
 }

--- a/src/main/java/org/folio/finc/dao/FileDAOImpl.java
+++ b/src/main/java/org/folio/finc/dao/FileDAOImpl.java
@@ -8,50 +8,35 @@ import org.folio.finc.model.File;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.utils.Constants;
 
 public class FileDAOImpl implements FileDAO {
 
-  private static final String ID_FIELD = "id";
-  private static final String TABLE_NAME = "files";
+  @Override
+  public Future<File> getById(String id, Context vertxContext) {
+    Criteria idCrit =
+        new Criteria().addField("id").setJSONB(false).setOperation("=").setVal(id);
+    Criterion criterion = new Criterion(idCrit);
+    return getByCriterion(criterion, vertxContext);
+  }
 
   @Override
-  public Future<File> getById(String id, String isil, Context vertxContext) {
+  public Future<File> getByCriterion(Criterion criterion, Context vertxContext) {
     Promise<File> result = Promise.promise();
-    Criterion criterion = getCriterion(id, isil);
-    CQLWrapper cql = new CQLWrapper(criterion);
     PostgresClient.getInstance(vertxContext.owner(), Constants.MODULE_TENANT)
         .get(
             TABLE_NAME,
             File.class,
-            cql,
+            criterion,
             false,
             reply -> {
               if (reply.succeeded()) {
                 List<File> fileList = reply.result().getResults();
-
-                if (fileList.size() > 1) {
-                  result.fail(
-                      "Error while getting file by id. Found "
-                          + fileList.size()
-                          + " entries for id "
-                          + id
-                          + ".");
-                }
-
                 File file;
                 if (fileList.isEmpty()) {
                   file = null;
                 } else {
                   file = fileList.get(0);
-                  if (!(id.equals(file.getId()))) {
-                    result.fail(
-                        "Error while getting file by id. Ids do not match. Expected: "
-                            + id
-                            + " - Actual: "
-                            + file.getId());
-                  }
                 }
                 result.complete(file);
               } else {
@@ -59,52 +44,5 @@ public class FileDAOImpl implements FileDAO {
               }
             });
     return result.future();
-  }
-
-  @Override
-  public Future<File> upsert(File entity, String id, Context vertxContext) {
-    Promise<File> result = Promise.promise();
-    PostgresClient.getInstance(vertxContext.owner(), Constants.MODULE_TENANT)
-        .upsert(
-            TABLE_NAME,
-            id,
-            entity,
-            asyncResult -> {
-              if (asyncResult.succeeded()) {
-                result.complete(entity);
-              } else {
-                result.fail("Cannot upsert file: " + asyncResult.cause());
-              }
-            });
-    return result.future();
-  }
-
-  @Override
-  public Future<Integer> deleteById(String id, String isil, Context vertxContext) {
-    Promise<Integer> result = Promise.promise();
-    Criterion criterion = getCriterion(id, isil);
-    PostgresClient.getInstance(vertxContext.owner(), Constants.MODULE_TENANT)
-        .delete(
-            TABLE_NAME,
-            criterion,
-            reply -> {
-              if (reply.succeeded()) {
-                result.complete(reply.result().getUpdated());
-              } else {
-                result.fail(reply.cause());
-              }
-            });
-    return result.future();
-  }
-
-  private Criterion getCriterion(String id, String isil) {
-    Criteria idCrit =
-        new Criteria().addField(ID_FIELD).setJSONB(false).setOperation("=").setVal(id);
-    Criterion criterion = new Criterion(idCrit);
-
-    Criteria isilCrit =
-        new Criteria().addField("'isil'").setJSONB(true).setOperation("=").setVal(isil);
-    criterion.addCriterion(isilCrit);
-    return criterion;
   }
 }

--- a/src/main/java/org/folio/finc/dao/FileDAOImpl.java
+++ b/src/main/java/org/folio/finc/dao/FileDAOImpl.java
@@ -12,6 +12,8 @@ import org.folio.rest.utils.Constants;
 
 public class FileDAOImpl implements FileDAO {
 
+  private static final String TABLE_NAME = "files";
+
   @Override
   public Future<File> getById(String id, Context vertxContext) {
     Criteria idCrit =

--- a/src/main/java/org/folio/finc/dao/SelectFileDAO.java
+++ b/src/main/java/org/folio/finc/dao/SelectFileDAO.java
@@ -1,0 +1,14 @@
+package org.folio.finc.dao;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import org.folio.finc.model.File;
+
+public interface SelectFileDAO {
+
+  Future<File> getById(String id, String isil, Context vertxContext);
+
+  Future<File> upsert(File entity, String id, Context vertxContext);
+
+  Future<Integer> deleteById(String id, String isil, Context vertxContext);
+}

--- a/src/main/java/org/folio/finc/dao/SelectFileDAOImpl.java
+++ b/src/main/java/org/folio/finc/dao/SelectFileDAOImpl.java
@@ -1,0 +1,70 @@
+package org.folio.finc.dao;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.folio.finc.model.File;
+import org.folio.rest.persist.Criteria.Criteria;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.utils.Constants;
+
+public class SelectFileDAOImpl implements SelectFileDAO {
+
+  private static final String ID_FIELD = "id";
+  private static final String TABLE_NAME = "files";
+  private final FileDAO fileDAO = new FileDAOImpl();
+
+  @Override
+  public Future<File> getById(String id, String isil, Context vertxContext) {
+    Criterion criterion = getCriterion(id, isil);
+    return fileDAO.getByCriterion(criterion, vertxContext);
+  }
+
+  @Override
+  public Future<File> upsert(File entity, String id, Context vertxContext) {
+    Promise<File> result = Promise.promise();
+    PostgresClient.getInstance(vertxContext.owner(), Constants.MODULE_TENANT)
+        .upsert(
+            TABLE_NAME,
+            id,
+            entity,
+            asyncResult -> {
+              if (asyncResult.succeeded()) {
+                result.complete(entity);
+              } else {
+                result.fail("Cannot upsert file: " + asyncResult.cause());
+              }
+            });
+    return result.future();
+  }
+
+  @Override
+  public Future<Integer> deleteById(String id, String isil, Context vertxContext) {
+    Promise<Integer> result = Promise.promise();
+    Criterion criterion = getCriterion(id, isil);
+    PostgresClient.getInstance(vertxContext.owner(), Constants.MODULE_TENANT)
+        .delete(
+            TABLE_NAME,
+            criterion,
+            reply -> {
+              if (reply.succeeded()) {
+                result.complete(reply.result().getUpdated());
+              } else {
+                result.fail(reply.cause());
+              }
+            });
+    return result.future();
+  }
+
+  private Criterion getCriterion(String id, String isil) {
+    Criteria idCrit =
+        new Criteria().addField(ID_FIELD).setJSONB(false).setOperation("=").setVal(id);
+    Criterion criterion = new Criterion(idCrit);
+
+    Criteria isilCrit =
+        new Criteria().addField("'isil'").setJSONB(true).setOperation("=").setVal(isil);
+    criterion.addCriterion(isilCrit);
+    return criterion;
+  }
+}

--- a/src/main/java/org/folio/finc/dao/SelectFilterDAO.java
+++ b/src/main/java/org/folio/finc/dao/SelectFilterDAO.java
@@ -5,7 +5,7 @@ import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.FincSelectFilter;
 import org.folio.rest.jaxrs.model.FincSelectFilters;
 
-public interface FilterDAO {
+public interface SelectFilterDAO {
 
   Future<FincSelectFilters> getAll(
       String query, int offset, int limit, String isil, Context vertxContext);

--- a/src/main/java/org/folio/finc/dao/SelectFilterDAOImpl.java
+++ b/src/main/java/org/folio/finc/dao/SelectFilterDAOImpl.java
@@ -6,7 +6,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.UpdateResult;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.folio.cql2pgjson.CQL2PgJSON;
@@ -23,16 +23,16 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.utils.Constants;
 
-public class FilterDAOImpl implements FilterDAO {
+public class SelectFilterDAOImpl implements SelectFilterDAO {
 
   private static final String ID_FIELD = "id";
   private static final String TABLE_NAME = "filters";
 
-  private final Logger logger = LoggerFactory.getLogger(FilterDAOImpl.class);
+  private final Logger logger = LoggerFactory.getLogger(SelectFilterDAOImpl.class);
 
   private final QueryTranslator queryTranslator;
 
-  public FilterDAOImpl() {
+  public SelectFilterDAOImpl() {
     queryTranslator = new MetadataCollectionsQueryTranslator();
   }
 
@@ -183,10 +183,8 @@ public class FilterDAOImpl implements FilterDAO {
 
   private CQLWrapper getCQL(String query, int limit, int offset, String isil)
       throws FieldException {
-    CQL2PgJSON cql2PgJSON = new CQL2PgJSON(Arrays.asList(TABLE_NAME + ".jsonb"));
-
+    CQL2PgJSON cql2PgJSON = new CQL2PgJSON(Collections.singletonList(TABLE_NAME + ".jsonb"));
     query = addIsilTo(query, isil);
-
     return new CQLWrapper(cql2PgJSON, query)
         .setLimit(new Limit(limit))
         .setOffset(new Offset(offset));

--- a/src/main/java/org/folio/finc/select/FilterHelper.java
+++ b/src/main/java/org/folio/finc/select/FilterHelper.java
@@ -8,10 +8,10 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.folio.finc.dao.FileDAO;
-import org.folio.finc.dao.FileDAOImpl;
-import org.folio.finc.dao.FilterDAO;
-import org.folio.finc.dao.FilterDAOImpl;
+import org.folio.finc.dao.SelectFileDAO;
+import org.folio.finc.dao.SelectFileDAOImpl;
+import org.folio.finc.dao.SelectFilterDAO;
+import org.folio.finc.dao.SelectFilterDAOImpl;
 import org.folio.rest.jaxrs.model.FilterFile;
 import org.folio.rest.jaxrs.model.FincSelectFilter;
 
@@ -19,19 +19,19 @@ public class FilterHelper {
 
   private static final Logger logger = LoggerFactory.getLogger(FilterHelper.class);
 
-  private final FilterDAO filterDAO;
-  private final FileDAO fileDAO;
+  private final SelectFilterDAO selectFilterDAO;
+  private final SelectFileDAO selectFileDAO;
 
   public FilterHelper() {
-    this.filterDAO = new FilterDAOImpl();
-    this.fileDAO = new FileDAOImpl();
+    this.selectFilterDAO = new SelectFilterDAOImpl();
+    this.selectFileDAO = new SelectFileDAOImpl();
   }
 
   public Future<Void> deleteFilesOfFilter(String filterId, String isil, Context vertxContext) {
 
     Promise<Void> result = Promise.promise();
 
-    Future<FincSelectFilter> byId = filterDAO.getById(filterId, isil, vertxContext);
+    Future<FincSelectFilter> byId = selectFilterDAO.getById(filterId, isil, vertxContext);
     byId.compose(fincSelectFilter -> deleteFilesOfFilter(fincSelectFilter, isil, vertxContext))
         .setHandler(
             voidAsyncResult -> {
@@ -54,7 +54,7 @@ public class FilterHelper {
     } else {
       List<Future> deleteFutures =
           filterFiles.stream()
-              .map(filterFile -> fileDAO.deleteById(filterFile.getFileId(), isil, vertxContext))
+              .map(filterFile -> selectFileDAO.deleteById(filterFile.getFileId(), isil, vertxContext))
               .collect(Collectors.toList());
 
       CompositeFuture.all(deleteFutures)
@@ -88,7 +88,7 @@ public class FilterHelper {
     List<Future> filesToDeleteFuture =
         filter.getFilterFiles().stream()
             .filter(filterFile -> filterFile.getDelete() != null && filterFile.getDelete())
-            .map(filterFile -> fileDAO.deleteById(filterFile.getFileId(), isil, vertxContext))
+            .map(filterFile -> selectFileDAO.deleteById(filterFile.getFileId(), isil, vertxContext))
             .collect(Collectors.toList());
 
     Promise<FincSelectFilter> result = Promise.promise();

--- a/src/main/java/org/folio/rest/impl/FincConfigFilesAPI.java
+++ b/src/main/java/org/folio/rest/impl/FincConfigFilesAPI.java
@@ -1,0 +1,36 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.folio.finc.dao.FileDAO;
+import org.folio.finc.dao.FileDAOImpl;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.resource.FincConfigFiles;
+
+public class FincConfigFilesAPI extends FincFileHandler implements FincConfigFiles {
+
+  private final FileDAO fileDAO;
+
+  public FincConfigFilesAPI() {
+    this.fileDAO = new FileDAOImpl();
+  }
+
+  @Override
+  @Validate
+  public void getFincConfigFilesById(String id, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    fileDAO.getById(id, vertxContext)
+        .setHandler(
+            ar ->
+                handleAsyncFileReponse(
+                    ar,
+                    GetFincConfigFilesByIdResponse::respond200WithApplicationOctetStream,
+                    GetFincConfigFilesByIdResponse::respond404WithTextPlain,
+                    GetFincConfigFilesByIdResponse::respond500WithTextPlain,
+                    asyncResultHandler)
+        );
+  }
+}

--- a/src/main/java/org/folio/rest/impl/FincConfigFiltersAPI.java
+++ b/src/main/java/org/folio/rest/impl/FincConfigFiltersAPI.java
@@ -1,0 +1,74 @@
+package org.folio.rest.impl;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.FincConfigFiltersGetOrder;
+import org.folio.rest.jaxrs.model.FincSelectFilter;
+import org.folio.rest.jaxrs.model.FincSelectFilterToCollections;
+import org.folio.rest.jaxrs.model.FincSelectFilters;
+import org.folio.rest.jaxrs.resource.FincConfigFilters;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.utils.Constants;
+
+public class FincConfigFiltersAPI implements FincConfigFilters {
+
+  private static final String TABLE_NAME = "filters";
+  public static final String X_OKAPI_TENANT = "x-okapi-tenant";
+
+  @Override
+  @Validate
+  public void getFincConfigFilters(String query, String orderBy, FincConfigFiltersGetOrder order,
+      int offset, int limit, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    okapiHeaders.put(X_OKAPI_TENANT, Constants.MODULE_TENANT);
+    PgUtil.get(TABLE_NAME, FincSelectFilter.class, FincSelectFilters.class, query, offset, limit,
+        okapiHeaders, vertxContext, GetFincConfigFiltersResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  public void postFincConfigFilters(String lang, FincSelectFilter entity,
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+    vertxContext.runOnContext(
+        aVoid -> asyncResultHandler.handle(succeededFuture(Response.status(501).build())));
+  }
+
+  @Override
+  @Validate
+  public void getFincConfigFiltersById(String id, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    okapiHeaders.put(X_OKAPI_TENANT, Constants.MODULE_TENANT);
+    PgUtil.getById(TABLE_NAME, FincSelectFilter.class, id, okapiHeaders, vertxContext,
+        GetFincConfigFiltersByIdResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  public void deleteFincConfigFiltersById(String id, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    vertxContext.runOnContext(
+        aVoid -> asyncResultHandler.handle(succeededFuture(Response.status(501).build())));
+  }
+
+  @Override
+  public void putFincConfigFiltersById(String id, String lang, FincSelectFilter entity,
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
+    vertxContext.runOnContext(
+        aVoid -> asyncResultHandler.handle(succeededFuture(Response.status(501).build())));
+  }
+
+  @Override
+  @Validate
+  public void getFincConfigFiltersCollectionsById(String id, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    okapiHeaders.put(X_OKAPI_TENANT, Constants.MODULE_TENANT);
+    PgUtil.getById("filter_to_collections", FincSelectFilterToCollections.class, id, okapiHeaders,
+        vertxContext, GetFincConfigFiltersCollectionsByIdResponse.class, asyncResultHandler);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/FincFileHandler.java
+++ b/src/main/java/org/folio/rest/impl/FincFileHandler.java
@@ -1,0 +1,51 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import java.util.Base64;
+import java.util.function.Function;
+import org.folio.finc.model.File;
+import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
+import org.folio.rest.tools.utils.BinaryOutStream;
+
+public abstract class FincFileHandler {
+
+  protected void handleAsyncFileReponse(AsyncResult<File> ar,
+      Function<BinaryOutStream, ResponseDelegate> func200,
+      Function<String, ResponseDelegate> func404, Function<Throwable, ResponseDelegate> func500,
+      io.vertx.core.Handler<io.vertx.core.AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler) {
+    if (ar.succeeded()) {
+      handleFileResponse(
+          ar.result(),
+          func200,
+          func404,
+          asyncResultHandler);
+    } else {
+      asyncResultHandler.handle(
+          Future.succeededFuture(
+              func500.apply(ar.cause())));
+    }
+  }
+
+  private void handleFileResponse(File file,
+      Function<BinaryOutStream, ResponseDelegate> succeedFunc,
+      Function<String, ResponseDelegate> failFunc,
+      io.vertx.core.Handler<io.vertx.core.AsyncResult<javax.ws.rs.core.Response>> asyncResultHandler) {
+    if (file == null) {
+      asyncResultHandler.handle(
+          Future.succeededFuture(
+              failFunc.apply("Not found")));
+    } else {
+      String dataAsString = file.getData();
+      byte[] decoded = Base64.getDecoder().decode(dataAsString);
+
+      BinaryOutStream binaryOutStream = new BinaryOutStream();
+      binaryOutStream.setData(decoded);
+      asyncResultHandler.handle(
+          Future.succeededFuture(
+              succeedFunc.apply(binaryOutStream)));
+    }
+  }
+
+
+}

--- a/src/test/java/org/folio/finc/ApiTestBase.java
+++ b/src/test/java/org/folio/finc/ApiTestBase.java
@@ -25,6 +25,8 @@ public class ApiTestBase {
   protected static final String FINC_CONFIG_METADATA_COLLECTIONS_ENDPOINT = "/finc-config/metadata-collections";
   protected static final String FINC_CONFIG_METADATA_SOURCES_ENDPOINT = "/finc-config/metadata-sources";
   protected static final String FINC_CONFIG_TINY_METADATA_SOURCES_ENDPOINT = "/finc-config/tiny-metadata-sources";
+  protected static final String FINC_CONFIG_FILTERS_ENDPOINT = "/finc-config/filters";
+  protected static final String FINC_CONFIG_FILES_ENDPOINT = "/finc-config/files";
 
   private static boolean runningOnOwn;
 

--- a/src/test/java/org/folio/finc/ApiTestSuite.java
+++ b/src/test/java/org/folio/finc/ApiTestSuite.java
@@ -14,6 +14,8 @@ import java.util.concurrent.TimeoutException;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.folio.finc.config.ConfigFilesIT;
+import org.folio.finc.config.ConfigFiltersIT;
 import org.folio.finc.config.ConfigMetadataCollectionsIT;
 import org.folio.finc.config.ConfigMetadataSourcesIT;
 import org.folio.finc.config.TinyMetadataSourcesIT;
@@ -35,14 +37,16 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-  ConfigMetadataCollectionsIT.class,
-  ConfigMetadataSourcesIT.class,
-  FincSelectFilesIT.class,
-  FincSelectFiltersIT.class,
-  IsilsIT.class,
-  SelectMetadataCollectionsIT.class,
-  SelectMetadataSourcesIT.class,
-  TinyMetadataSourcesIT.class
+    ConfigMetadataCollectionsIT.class,
+    ConfigMetadataSourcesIT.class,
+    ConfigFiltersIT.class,
+    ConfigFilesIT.class,
+    FincSelectFilesIT.class,
+    FincSelectFiltersIT.class,
+    IsilsIT.class,
+    SelectMetadataCollectionsIT.class,
+    SelectMetadataSourcesIT.class,
+    TinyMetadataSourcesIT.class
 })
 public class ApiTestSuite {
 

--- a/src/test/java/org/folio/finc/config/ConfigFilesIT.java
+++ b/src/test/java/org/folio/finc/config/ConfigFilesIT.java
@@ -1,0 +1,82 @@
+package org.folio.finc.config;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.response.Response;
+import io.vertx.ext.unit.junit.Timeout;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.UUID;
+import org.folio.finc.ApiTestBase;
+import org.folio.rest.jaxrs.model.Isil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class ConfigFilesIT extends ApiTestBase {
+
+  private static final String TEST_CONTENT = "This is the test content!!!!";
+  @Rule
+  public Timeout timeout = Timeout.seconds(10);
+  private Isil isilUbl;
+  private Isil isilDiku;
+
+  @Before
+  public void init() {
+    isilUbl = loadIsilUbl();
+    isilDiku = loadIsilDiku();
+  }
+
+  @After
+  public void tearDown() {
+    deleteIsil(isilUbl.getId());
+    deleteIsil(isilDiku.getId());
+  }
+
+  @Test
+  public void checkThatWeCanGetAFile() {
+    // POST File
+    Response postResponse =
+        given()
+            .body(TEST_CONTENT.getBytes())
+            .header("X-Okapi-Tenant", TENANT_UBL)
+            .header("content-type", ContentType.BINARY)
+            .post(FINC_SELECT_FILES_ENDPOINT)
+            .then()
+            .statusCode(200)
+            .extract()
+            .response();
+    String id = postResponse.getBody().print();
+
+    // GET
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .header("content-type", ContentType.BINARY)
+        .get(FINC_CONFIG_FILES_ENDPOINT + "/" + id)
+        .then()
+        .contentType(ContentType.BINARY.toString())
+        .statusCode(200)
+        .body(equalTo(TEST_CONTENT));
+
+    // GET by unknown id
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .header("content-type", ContentType.TEXT)
+        .get(FINC_CONFIG_FILES_ENDPOINT + "/" + UUID.randomUUID().toString())
+        .then()
+        .contentType(ContentType.TEXT)
+        .statusCode(404);
+
+    // DELETE
+    given()
+        .header("X-Okapi-Tenant", TENANT_UBL)
+        .delete(FINC_SELECT_FILES_ENDPOINT + "/" + id)
+        .then()
+        .statusCode(204);
+  }
+
+}

--- a/src/test/java/org/folio/finc/config/ConfigFiltersIT.java
+++ b/src/test/java/org/folio/finc/config/ConfigFiltersIT.java
@@ -1,0 +1,166 @@
+package org.folio.finc.config;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.jayway.restassured.http.ContentType;
+import io.vertx.core.json.Json;
+import io.vertx.ext.unit.junit.Timeout;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.UUID;
+import org.folio.finc.ApiTestBase;
+import org.folio.rest.jaxrs.model.FincSelectFilter;
+import org.folio.rest.jaxrs.model.FincSelectFilter.Type;
+import org.folio.rest.jaxrs.model.Isil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class ConfigFiltersIT extends ApiTestBase {
+
+  @Rule
+  public Timeout timeout = Timeout.seconds(10);
+  private Isil isilUBL;
+  private Isil isilDiku;
+  private FincSelectFilter filterUBL;
+  private FincSelectFilter filterDIKU;
+
+  @Before
+  public void init() {
+    isilDiku = loadIsilDiku();
+    isilUBL = loadIsilUbl();
+
+    filterUBL =
+        new FincSelectFilter()
+            .withLabel("Filter UBL")
+            .withId(UUID.randomUUID().toString())
+            .withType(Type.WHITELIST);
+    filterDIKU =
+        new FincSelectFilter()
+            .withLabel("Filter Diku")
+            .withId(UUID.randomUUID().toString())
+            .withType(Type.BLACKLIST);
+  }
+
+  @After
+  public void tearDown() {
+    deleteIsil(isilDiku.getId());
+    deleteIsil(isilUBL.getId());
+  }
+
+  @Test
+  public void checkThatWeCanAddAndGetFilters() {
+    filterUBL.setId(UUID.randomUUID().toString());
+    filterDIKU.setId(UUID.randomUUID().toString());
+
+    // POST
+    given()
+        .body(Json.encode(filterUBL))
+        .header("X-Okapi-Tenant", TENANT_UBL)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .post(FINC_SELECT_FILTERS_ENDPOINT)
+        .then()
+        .statusCode(201)
+        .body("id", equalTo(filterUBL.getId()))
+        .body("label", equalTo(filterUBL.getLabel()))
+        .body("type", equalTo(filterUBL.getType().value()));
+
+    // POST
+    given()
+        .body(Json.encode(filterDIKU))
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .post(FINC_SELECT_FILTERS_ENDPOINT)
+        .then()
+        .statusCode(201)
+        .body("id", equalTo(filterDIKU.getId()))
+        .body("label", equalTo(filterDIKU.getLabel()))
+        .body("type", equalTo(filterDIKU.getType().value()));
+
+    // GET all filters
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .get(FINC_CONFIG_FILTERS_ENDPOINT)
+        .then()
+        .contentType(ContentType.JSON)
+        .statusCode(200)
+        .body("fincSelectFilters.size()", equalTo(2));
+
+    // GET filter ubl
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .get(FINC_CONFIG_FILTERS_ENDPOINT + "/" + filterUBL.getId())
+        .then()
+        .contentType(ContentType.JSON)
+        .statusCode(200)
+        .body("id", equalTo(filterUBL.getId()))
+        .body("label", equalTo(filterUBL.getLabel()))
+        .body("type", equalTo(filterUBL.getType().value()));
+
+    // GET filter diku
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .get(FINC_CONFIG_FILTERS_ENDPOINT + "/" + filterDIKU.getId())
+        .then()
+        .contentType(ContentType.JSON)
+        .statusCode(200)
+        .body("id", equalTo(filterDIKU.getId()))
+        .body("label", equalTo(filterDIKU.getLabel()))
+        .body("type", equalTo(filterDIKU.getType().value()));
+
+    // DELETE filters
+    given()
+        .header("X-Okapi-Tenant", TENANT_UBL)
+        .delete(FINC_SELECT_FILTERS_ENDPOINT + "/" + filterUBL.getId())
+        .then()
+        .statusCode(204);
+
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .delete(FINC_SELECT_FILTERS_ENDPOINT + "/" + filterDIKU.getId())
+        .then()
+        .statusCode(204);
+
+  }
+
+  @Test
+  public void checkUnimplementedEndpoints() {
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .body(Json.encode(filterUBL))
+        .post(FINC_CONFIG_FILTERS_ENDPOINT)
+        .then()
+        .contentType(ContentType.JSON)
+        .statusCode(501);
+
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.TEXT)
+        .body(Json.encode(filterUBL))
+        .put(FINC_CONFIG_FILTERS_ENDPOINT + "/" + filterUBL.getId())
+        .then()
+        .contentType(ContentType.JSON)
+        .statusCode(501);
+
+    given()
+        .header("X-Okapi-Tenant", TENANT_DIKU)
+        .delete(FINC_CONFIG_FILTERS_ENDPOINT + "/" + filterUBL.getId())
+        .then()
+        .statusCode(501);
+  }
+
+}

--- a/src/test/java/org/folio/finc/config/TinyMetadataSourcesIT.java
+++ b/src/test/java/org/folio/finc/config/TinyMetadataSourcesIT.java
@@ -5,9 +5,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 import com.jayway.restassured.http.ContentType;
 import io.vertx.core.json.Json;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.finc.mocks.MockOrganization;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(VertxUnitRunner.class)
 public class TinyMetadataSourcesIT extends AbstractMetadataSourcesIT {
 
   @Test


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODGOBI-43 Move "Renewals" information to Purchase Order level

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
In order to make processing of information stored convenient, /finc-config/ needs to have endopoints to get filters and files. 
This PR add the endpoints

- /finc-config/filters
- /finc-config/files

<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODGOBI-43
 -->

## Approach
Return filters and files not seperated by tenant.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less --> Sonarcloud detects similar code which is no duplicate as duplicate.
  - [ ] There are no major code smells or security issues 
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
