### PR TITLE
Add btree index on collection's mdSource.id

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -63,6 +63,14 @@
           "fieldName": "collectionId",
           "tOps": "ADD"
         }
+      ],
+      "index": [
+        {
+          "fieldName": "mdSource.id",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
       ]
     },
     {


### PR DESCRIPTION
Add btree index, to enable '==' search which in turn enables to estimate number of collections with a certain mdSource.id more precisely