### PR TITLE
FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 buildMvn {
   publishModDescriptor = true
-  publishAPI = true
   mvnDeploy = true
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,12 @@
 buildMvn {
   publishModDescriptor = true
-  runLintRamlCop = true
   publishAPI = true
   mvnDeploy = true
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/ramls/examples/fincConfigMetadataSource_collection.sample
+++ b/ramls/examples/fincConfigMetadataSource_collection.sample
@@ -25,7 +25,7 @@
           "name": "Doe, Jane",
           "role": "vendor"
         }
-      ],
+      ]
     },
     {
       "id": "8ac1e1cf-5128-46b9-b57b-52bbfca7261b",
@@ -56,7 +56,7 @@
           "name": "Doe, Jane",
           "role": "vendor"
         }
-      ],
+      ]
     }
   ],
   "totalRecords": 2


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#mod-finc-config section of API documentation will be automatically reconfigured:
https://dev.folio.org/reference/api/#explain-gather-config