### PR TITLE
[UIFC-406] Increase maximum allowed string length to 50MB in Jacksons ObjectMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -480,9 +480,8 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
-                    <Main-Class>org.folio.rest.RestLauncher</Main-Class>
+                    <Main-Class>org.folio.rest.FincConfigLauncher</Main-Class>
                     <Main-Verticle>org.folio.rest.RestVerticle</Main-Verticle>
-                    <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
               </transformers>

--- a/src/main/java/org/folio/rest/FincConfigLauncher.java
+++ b/src/main/java/org/folio/rest/FincConfigLauncher.java
@@ -1,0 +1,30 @@
+package org.folio.rest;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.json.jackson.DatabindCodec;
+
+public class FincConfigLauncher extends RestLauncher {
+
+  public static void main(String[] args) {
+    new FincConfigLauncher().dispatch(args);
+  }
+
+  @Override
+  public void beforeStartingVertx(VertxOptions options) {
+    super.beforeStartingVertx(options);
+
+    ObjectMapper objectMapper = DatabindCodec.mapper();
+    JsonFactory factory = objectMapper.getFactory();
+
+    // Modify only the max string length constraint
+    factory.setStreamReadConstraints(
+        StreamReadConstraints.builder()
+            .maxStringLength(50 * 1024 * 1024) // Increase limit to 50 MB
+            .build());
+    System.out.println(
+        "Increased max string length to 50 MB for JSON parsing. (FincConfigLauncher)");
+  }
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIFC-406