### PR TITLE
[UIFC-404] Provide filter information in metadata collections

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -64,7 +64,7 @@
     },
     {
       "id": "finc-config-metadata-collections",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": [

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.12.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -91,6 +99,27 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- JUnit 5 dependencies -->
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -533,7 +562,7 @@
             <exclude>**/*IT.java</exclude>
           </excludes>
           <includes>
-            <include>**/ApiTestSuite.java</include>
+            <include>**/*TestSuite.java</include>
             <include>**/*ITest.java</include>
           </includes>
           <environmentVariables>

--- a/ramls/fincConfigMetadataCollections.raml
+++ b/ramls/fincConfigMetadataCollections.raml
@@ -10,6 +10,8 @@ documentation:
 types:
   fincConfigMetadataCollection: !include schemas/fincConfigMetadataCollection.json
   fincConfigMetadataCollections: !include schemas/fincConfigMetadataCollections.json
+  fincConfigMetadataCollectionWithFilters: !include schemas/fincConfigMetadataCollectionWithFilters.json
+  fincConfigMetadataCollectionWithFiltersCollection: !include schemas/fincConfigMetadataCollectionWithFiltersCollection.json
   errors: !include ./raml-util/schemas/errors.schema
 
 traits:
@@ -17,6 +19,7 @@ traits:
   pageable: !include ./raml-util/traits/pageable.raml
   searchable: !include ./raml-util/traits/searchable.raml
   validate: !include ./raml-util/traits/validation.raml
+  include_filtered_by: !include ./traits/include_filtered_by.raml
 
 resourceTypes:
   collection: !include ./raml-util/rtypes/collection.raml
@@ -34,9 +37,15 @@ resourceTypes:
     is: [
       searchable: {description: "", example: "((label=\"Science*\") and metadataAvailable=(\"yes\" or \"no\")) sortby label"},
       orderable: {fieldsList: "label, mdSource, metadataAvailable, usageRestricted, permittedFor, freeContent"},
-      pageable
+      pageable,
+      include_filtered_by
     ]
     description: Get all metadata collections
+    responses:
+      200:
+        body:
+          application/json:
+            type: fincConfigMetadataCollectionWithFiltersCollection
   post:
     is: [validate]
     description: Post new metadata collection
@@ -46,7 +55,13 @@ resourceTypes:
         exampleItem: !include examples/fincConfigMetadataCollection.sample
         schema: fincConfigMetadataCollection
     get:
+      is: [include_filtered_by]
       description: Get one metadata collection identified by id
+      responses:
+        200:
+          body:
+            application/json:
+              type: fincConfigMetadataCollectionWithFilters
     delete:
       description: Delete an metadata collection identified by id
     put:

--- a/ramls/schemas/fincConfigMetadataCollectionWithFilters.json
+++ b/ramls/schemas/fincConfigMetadataCollectionWithFilters.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Metadata Collection With Filters Schema",
+  "description": "Metadata collection with filters in finc config",
+  "type": "object",
+  "javaType": "org.folio.rest.jaxrs.model.FincConfigMetadataCollectionWithFilters",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string",
+      "description": "A unique name for this metadata collection"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description for this metadata collection"
+    },
+    "mdSource": {
+      "type": "object",
+      "description": "The metadata source this metadata collection belongs to",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Id of linked metadata source"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of linked metadata source"
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "metadataAvailable": {
+      "type": "string",
+      "description": "Indicates if metadata is available",
+      "enum": [
+        "yes",
+        "no",
+        "undetermined"
+      ]
+    },
+    "usageRestricted": {
+      "type": "string",
+      "description": "Indicates if usage is restricted",
+      "enum": [
+        "yes",
+        "no"
+      ]
+    },
+    "permittedFor": {
+      "type": "array",
+      "description": "List of isils (libraries) this metadata collection is permitted for",
+      "minItems": 0,
+      "items": {
+        "type": "string"
+      }
+    },
+    "freeContent": {
+      "type": "string",
+      "description": "Indicator is content is free",
+      "enum": [
+        "yes",
+        "no",
+        "undetermined"
+      ]
+    },
+    "lod": {
+      "type": "object",
+      "description": "Indicator if LOD publication is permitted",
+      "properties": {
+        "publication": {
+          "type": "string",
+          "description": "Indicator if publication is permitted",
+          "enum": [
+            "yes",
+            "no",
+            "undetermined"
+          ]
+        },
+        "note": {
+          "type": "string",
+          "description": "Note to LOD publication"
+        }
+      }
+    },
+    "collectionId": {
+      "type": "string",
+      "description": "Id of the collection"
+    },
+    "productIsil": {
+      "type": "string",
+      "description": "Isil of product"
+    },
+    "tickets": {
+      "type": "array",
+      "description": "List of links to corresponding tickets",
+      "minItems": 0,
+      "items": {
+        "type": "string"
+      }
+    },
+    "contentFiles": {
+      "type": "array",
+      "description": "URL to linked content file",
+      "minItems": 0,
+      "items": {
+        "type": "string"
+      }
+    },
+    "solrMegaCollections": {
+      "type": "array",
+      "description": "Link to solr mega collections",
+      "minItems": 0,
+      "items": {
+        "type": "string"
+      }
+    },
+    "selectedBy": {
+      "type": "array",
+      "description": "List of isils which selected this metadata collection",
+      "minItems": 0,
+      "items": {
+        "type": "string"
+      }
+    },
+    "filteredBy": {
+      "type": "array",
+      "description": "List of filters which include this metadata collection",
+      "items": {
+        "type": "object",
+        "$ref": "fincSelectFilter.json"
+      }
+    },
+    "generalNotes": {
+      "type": "string",
+      "description": "Some notes"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../raml-util/schemas/metadata.schema"
+    }
+  },
+  "required": [
+    "id",
+    "collectionId",
+    "label",
+    "usageRestricted",
+    "solrMegaCollections"
+  ],
+  "additionalProperties": false
+}

--- a/ramls/schemas/fincConfigMetadataCollectionWithFiltersCollection.json
+++ b/ramls/schemas/fincConfigMetadataCollectionWithFiltersCollection.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Collection of metadata collections with filters in finc config",
+  "javaType": "org.folio.rest.jaxrs.model.FincConfigMetadataCollectionWithFiltersCollection",
+  "properties": {
+    "fincConfigMetadataCollections": {
+      "type": "array",
+      "description": "List of metadata collections with filters in finc config",
+      "items": {
+        "type": "object",
+        "$ref": "fincConfigMetadataCollectionWithFilters.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "fincConfigMetadataCollections",
+    "totalRecords"
+  ]
+}

--- a/ramls/traits/include_filtered_by.raml
+++ b/ramls/traits/include_filtered_by.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0 Trait
+
+      queryParameters:
+        includeFilteredBy:
+          description: Whether to include filter information in the response
+          type: boolean
+          default: false
+          required: false

--- a/src/main/java/org/folio/rest/impl/GetFincConfigMetadataCollectionsResponse.java
+++ b/src/main/java/org/folio/rest/impl/GetFincConfigMetadataCollectionsResponse.java
@@ -5,7 +5,6 @@ import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 
 import javax.ws.rs.core.Response;
-
 import org.folio.rest.jaxrs.model.FincConfigMetadataCollection;
 import org.folio.rest.jaxrs.model.FincConfigMetadataCollectionWithFilters;
 import org.folio.rest.jaxrs.model.FincConfigMetadataCollectionWithFiltersCollection;
@@ -40,14 +39,14 @@ public class GetFincConfigMetadataCollectionsResponse extends ResponseDelegate {
   }
 
   public static GetFincConfigMetadataCollectionsResponse respond200WithApplicationJson(
-    FincConfigMetadataCollection entity) {
+      FincConfigMetadataCollection entity) {
     Response.ResponseBuilder responseBuilder = Response.status(200).header(CONTENT_TYPE, JSON);
     responseBuilder.entity(entity);
     return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
   }
 
   public static GetFincConfigMetadataCollectionsResponse respond200WithApplicationJson(
-    FincConfigMetadataCollectionWithFilters entity) {
+      FincConfigMetadataCollectionWithFilters entity) {
     Response.ResponseBuilder responseBuilder = Response.status(200).header(CONTENT_TYPE, JSON);
     responseBuilder.entity(entity);
     return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
@@ -69,7 +68,7 @@ public class GetFincConfigMetadataCollectionsResponse extends ResponseDelegate {
 
   public static GetFincConfigMetadataCollectionsResponse respond404WithTextPlain(Object entity) {
     Response.ResponseBuilder responseBuilder =
-      Response.status(404).header(CONTENT_TYPE, PLAIN_TEXT);
+        Response.status(404).header(CONTENT_TYPE, PLAIN_TEXT);
     responseBuilder.entity(entity);
     return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
   }

--- a/src/main/java/org/folio/rest/impl/GetFincConfigMetadataCollectionsResponse.java
+++ b/src/main/java/org/folio/rest/impl/GetFincConfigMetadataCollectionsResponse.java
@@ -1,0 +1,83 @@
+package org.folio.rest.impl;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.jaxrs.model.FincConfigMetadataCollection;
+import org.folio.rest.jaxrs.model.FincConfigMetadataCollectionWithFilters;
+import org.folio.rest.jaxrs.model.FincConfigMetadataCollectionWithFiltersCollection;
+import org.folio.rest.jaxrs.model.FincConfigMetadataCollections;
+import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
+
+public class GetFincConfigMetadataCollectionsResponse extends ResponseDelegate {
+
+  static final String JSON = JSON_UTF_8.withoutParameters().toString();
+  static final String PLAIN_TEXT = PLAIN_TEXT_UTF_8.withoutParameters().toString();
+
+  protected GetFincConfigMetadataCollectionsResponse(Response delegate, Object entity) {
+    super(delegate, entity);
+  }
+
+  protected GetFincConfigMetadataCollectionsResponse(Response delegate) {
+    super(delegate);
+  }
+
+  public static GetFincConfigMetadataCollectionsResponse respond200WithApplicationJson(
+      FincConfigMetadataCollectionWithFiltersCollection entity) {
+    Response.ResponseBuilder responseBuilder = Response.status(200).header(CONTENT_TYPE, JSON);
+    responseBuilder.entity(entity);
+    return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
+  }
+
+  public static GetFincConfigMetadataCollectionsResponse respond200WithApplicationJson(
+      FincConfigMetadataCollections entity) {
+    Response.ResponseBuilder responseBuilder = Response.status(200).header(CONTENT_TYPE, JSON);
+    responseBuilder.entity(entity);
+    return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
+  }
+
+  public static GetFincConfigMetadataCollectionsResponse respond200WithApplicationJson(
+    FincConfigMetadataCollection entity) {
+    Response.ResponseBuilder responseBuilder = Response.status(200).header(CONTENT_TYPE, JSON);
+    responseBuilder.entity(entity);
+    return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
+  }
+
+  public static GetFincConfigMetadataCollectionsResponse respond200WithApplicationJson(
+    FincConfigMetadataCollectionWithFilters entity) {
+    Response.ResponseBuilder responseBuilder = Response.status(200).header(CONTENT_TYPE, JSON);
+    responseBuilder.entity(entity);
+    return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
+  }
+
+  public static GetFincConfigMetadataCollectionsResponse respond400WithTextPlain(Object entity) {
+    Response.ResponseBuilder responseBuilder =
+        Response.status(400).header(CONTENT_TYPE, PLAIN_TEXT);
+    responseBuilder.entity(entity);
+    return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
+  }
+
+  public static GetFincConfigMetadataCollectionsResponse respond401WithTextPlain(Object entity) {
+    Response.ResponseBuilder responseBuilder =
+        Response.status(401).header(CONTENT_TYPE, PLAIN_TEXT);
+    responseBuilder.entity(entity);
+    return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
+  }
+
+  public static GetFincConfigMetadataCollectionsResponse respond404WithTextPlain(Object entity) {
+    Response.ResponseBuilder responseBuilder =
+      Response.status(404).header(CONTENT_TYPE, PLAIN_TEXT);
+    responseBuilder.entity(entity);
+    return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
+  }
+
+  public static GetFincConfigMetadataCollectionsResponse respond500WithTextPlain(Object entity) {
+    Response.ResponseBuilder responseBuilder =
+        Response.status(500).header(CONTENT_TYPE, PLAIN_TEXT);
+    responseBuilder.entity(entity);
+    return new GetFincConfigMetadataCollectionsResponse(responseBuilder.build(), entity);
+  }
+}

--- a/src/main/resources/templates/db_scripts/filter_to_collections.sql
+++ b/src/main/resources/templates/db_scripts/filter_to_collections.sql
@@ -1,0 +1,4 @@
+-- Add a GIN index for the join on collections.id for the metadata_collections_w_filters view
+DROP INDEX IF EXISTS filter_to_collections_collectionids_idx_gin;
+CREATE INDEX filter_to_collections_collectionids_idx_gin
+  ON filter_to_collections USING gin ((jsonb->'collectionIds'));

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -3,7 +3,7 @@
     {
       "run": "after",
       "snippetPath": "views.sql",
-      "fromModuleVersion": "mod-finc-config-3.0.0"
+      "fromModuleVersion": "mod-finc-config-6.2.0"
     },
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -227,7 +227,8 @@
     },
     {
       "tableName": "filter_to_collections",
-      "fromModuleVersion": "mod-finc-config-2.0.0",
+      "fromModuleVersion": "mod-finc-config-6.2.0",
+      "customSnippetPath": "filter_to_collections.sql",
       "withMetadata": true
     },
     {

--- a/src/main/resources/templates/db_scripts/views.sql
+++ b/src/main/resources/templates/db_scripts/views.sql
@@ -5,3 +5,12 @@ CREATE OR REPLACE VIEW filters_wo_isil AS SELECT id AS id, jsonb - 'isil' AS jso
 CREATE OR REPLACE VIEW metadata_sources_contacts AS SELECT DISTINCT ON (c.jsonb->>'name') c.jsonb
                                                     FROM (SELECT jsonb_array_elements(jsonb->'contacts') AS jsonb from finc_mod_finc_config.metadata_sources) AS c
                                                     ORDER BY c.jsonb->>'name';
+
+CREATE OR REPLACE VIEW metadata_collections_w_filters AS
+  SELECT
+    collections.id as id,
+    jsonb_set(collections.jsonb, '{filteredBy}', coalesce(jsonb_agg(filters.jsonb) FILTER (WHERE filters.id IS NOT NULL), '[]'::jsonb)) as jsonb
+  FROM metadata_collections collections
+  LEFT JOIN filter_to_collections f2c ON f2c.jsonb->'collectionIds' @> to_jsonb(collections.id)
+  LEFT JOIN filters filters ON f2c.id = filters.id
+  GROUP BY collections.id;

--- a/src/test/java/org/folio/finc/ApiTestBase.java
+++ b/src/test/java/org/folio/finc/ApiTestBase.java
@@ -2,16 +2,30 @@ package org.folio.finc;
 
 import io.restassured.http.ContentType;
 import io.vertx.core.json.Json;
+
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.Isil;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import static com.google.common.net.HttpHeaders.ACCEPT;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static com.google.common.net.MediaType.OCTET_STREAM;
 import static io.restassured.RestAssured.given;
+import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+
+import javax.print.attribute.standard.Media;
+
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
 
 public class ApiTestBase {
 
@@ -43,7 +57,6 @@ public class ApiTestBase {
 
   @BeforeClass
   public static void before() throws Exception {
-
     if (ApiTestSuite.isNotInitialised()) {
       System.out.println("Running test on own, initialising suite manually");
       runningOnOwn = true;
@@ -51,16 +64,25 @@ public class ApiTestBase {
     }
   }
 
+  @BeforeAll
+  static void beforeAll() throws Exception {
+    before();
+  }
+
   @AfterClass
   public static void after() throws InterruptedException, ExecutionException, TimeoutException {
-
     if (runningOnOwn) {
       System.out.println("Running test on own, un-initialising suite manually");
       ApiTestSuite.after();
     }
   }
 
-  public Isil loadIsilUbl() {
+  @AfterAll
+  static void afterAll() throws ExecutionException, InterruptedException, TimeoutException {
+    after();
+  }
+
+  public static Isil loadIsilUbl() {
     Isil isil =
         new Isil()
             .withId(UUID.randomUUID().toString())
@@ -70,7 +92,7 @@ public class ApiTestBase {
     return loadIsil(isil);
   }
 
-  public Isil loadIsilDiku() {
+  public static Isil loadIsilDiku() {
     Isil isil =
         new Isil()
             .withId(UUID.randomUUID().toString())
@@ -80,7 +102,7 @@ public class ApiTestBase {
     return loadIsil(isil);
   }
 
-  public Isil loadIsil(Isil isil) {
+  public static Isil loadIsil(Isil isil) {
     Isil isilResp =
         given()
             .body(Json.encode(isil))
@@ -103,5 +125,40 @@ public class ApiTestBase {
         .delete(ISILS_API_ENDPOINT + "/" + isilId)
         .then()
         .statusCode(204);
+  }
+
+  public static String post(String endpoint, Object entity, String tenantId) {
+    return given()
+        .body(Json.encode(entity))
+        .header(TENANT, tenantId)
+        .header(CONTENT_TYPE, JSON_UTF_8.withoutParameters().toString())
+        .post(endpoint)
+        .then()
+        .statusCode(201)
+        .extract()
+        .jsonPath()
+        .getString("id");
+  }
+
+  public static void put(String endpoint, Object entity, String tenantId) {
+    given()
+      .body(Json.encode(entity))
+      .header(TENANT, tenantId)
+      .header(CONTENT_TYPE, JSON_UTF_8.withoutParameters().toString())
+      .put(endpoint)
+      .then()
+      .statusCode(200);
+  }
+
+  public static String postFile(String content, String tenantId) {
+    return given()
+      .body(content.getBytes())
+      .header(TENANT, tenantId)
+      .header(CONTENT_TYPE, OCTET_STREAM.toString())
+      .post(FINC_SELECT_FILES_ENDPOINT)
+      .then()
+      .statusCode(200)
+      .extract()
+      .asString();
   }
 }

--- a/src/test/java/org/folio/finc/ApiTestBase.java
+++ b/src/test/java/org/folio/finc/ApiTestBase.java
@@ -1,31 +1,22 @@
 package org.folio.finc;
 
-import io.restassured.http.ContentType;
-import io.vertx.core.json.Json;
-
-import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.rest.jaxrs.model.Isil;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import static com.google.common.net.HttpHeaders.ACCEPT;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
 import static com.google.common.net.MediaType.OCTET_STREAM;
 import static io.restassured.RestAssured.given;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 
-import javax.print.attribute.standard.Media;
-
-import com.google.common.net.HttpHeaders;
-import com.google.common.net.MediaType;
+import io.restassured.http.ContentType;
+import io.vertx.core.json.Json;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import org.folio.rest.jaxrs.model.Isil;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class ApiTestBase {
 
@@ -142,23 +133,23 @@ public class ApiTestBase {
 
   public static void put(String endpoint, Object entity, String tenantId) {
     given()
-      .body(Json.encode(entity))
-      .header(TENANT, tenantId)
-      .header(CONTENT_TYPE, JSON_UTF_8.withoutParameters().toString())
-      .put(endpoint)
-      .then()
-      .statusCode(200);
+        .body(Json.encode(entity))
+        .header(TENANT, tenantId)
+        .header(CONTENT_TYPE, JSON_UTF_8.withoutParameters().toString())
+        .put(endpoint)
+        .then()
+        .statusCode(200);
   }
 
   public static String postFile(String content, String tenantId) {
     return given()
-      .body(content.getBytes())
-      .header(TENANT, tenantId)
-      .header(CONTENT_TYPE, OCTET_STREAM.toString())
-      .post(FINC_SELECT_FILES_ENDPOINT)
-      .then()
-      .statusCode(200)
-      .extract()
-      .asString();
+        .body(content.getBytes())
+        .header(TENANT, tenantId)
+        .header(CONTENT_TYPE, OCTET_STREAM.toString())
+        .post(FINC_SELECT_FILES_ENDPOINT)
+        .then()
+        .statusCode(200)
+        .extract()
+        .asString();
   }
 }

--- a/src/test/java/org/folio/finc/ApiTestSuite.java
+++ b/src/test/java/org/folio/finc/ApiTestSuite.java
@@ -62,13 +62,11 @@ public class ApiTestSuite {
   private static Vertx vertx;
   private static boolean initialised = false;
 
-  static {
-    vertx = Vertx.vertx();
-  }
-
   @BeforeClass
   public static void before()
       throws IOException, InterruptedException, ExecutionException, TimeoutException {
+
+    vertx = Vertx.vertx();
 
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
     PostgresClient client = PostgresClient.getInstance(vertx);

--- a/src/test/java/org/folio/finc/JUnit5ITTestSuite.java
+++ b/src/test/java/org/folio/finc/JUnit5ITTestSuite.java
@@ -1,6 +1,5 @@
-package org.folio.finc.select;
+package org.folio.finc;
 
-import org.folio.finc.ApiTestSuite;
 import org.folio.finc.config.ConfigMetadataCollectionsWithFiltersIT;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/src/test/java/org/folio/finc/JUnit5ITTestSuite.java
+++ b/src/test/java/org/folio/finc/JUnit5ITTestSuite.java
@@ -1,0 +1,30 @@
+package org.folio.finc.select;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.finc.ApiTestBase;
+import org.folio.finc.ApiTestSuite;
+import org.folio.finc.config.ConfigMetadataCollectionsWithFiltersIT;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class JUnit5ITTestSuite {
+
+  @BeforeAll
+  static void beforeAll() throws Exception {
+    ApiTestSuite.before();
+  }
+
+  @AfterAll
+  static void afterAll() throws Exception {
+    ApiTestSuite.after();
+  }
+
+  @Nested
+  class ConfigMetadataCollectionsWithFiltersITNested
+      extends ConfigMetadataCollectionsWithFiltersIT {}
+}

--- a/src/test/java/org/folio/finc/JUnit5ITTestSuite.java
+++ b/src/test/java/org/folio/finc/JUnit5ITTestSuite.java
@@ -1,16 +1,10 @@
 package org.folio.finc.select;
 
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import org.folio.finc.ApiTestBase;
 import org.folio.finc.ApiTestSuite;
 import org.folio.finc.config.ConfigMetadataCollectionsWithFiltersIT;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 
 class JUnit5ITTestSuite {
 

--- a/src/test/java/org/folio/finc/TenantITest.java
+++ b/src/test/java/org/folio/finc/TenantITest.java
@@ -169,6 +169,6 @@ public class TenantITest {
         .header("accept", ContentType.JSON)
         .get(FINC_CONFIG_METADATA_COLLECTIONS_ENDPOINT)
         .then()
-        .statusCode(500);
+        .statusCode(400);
   }
 }

--- a/src/test/java/org/folio/finc/config/ConfigMetadataCollectionsWithFiltersIT.java
+++ b/src/test/java/org/folio/finc/config/ConfigMetadataCollectionsWithFiltersIT.java
@@ -1,0 +1,202 @@
+package org.folio.finc.config;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+import static org.folio.rest.jaxrs.model.FincSelectFilter.Type.BLACKLIST;
+import static org.folio.rest.jaxrs.model.FincSelectFilter.Type.WHITELIST;
+import static org.folio.rest.utils.Constants.MODULE_TENANT;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.assertj.core.api.ThrowingConsumer;
+import org.folio.finc.ApiTestBase;
+import org.folio.rest.jaxrs.model.FilterFile;
+import org.folio.rest.jaxrs.model.FilteredBy;
+import org.folio.rest.jaxrs.model.FincConfigMetadataCollection;
+import org.folio.rest.jaxrs.model.FincConfigMetadataCollectionWithFilters;
+import org.folio.rest.jaxrs.model.FincConfigMetadataCollectionWithFiltersCollection;
+import org.folio.rest.jaxrs.model.FincConfigMetadataCollections;
+import org.folio.rest.jaxrs.model.FincSelectFilter;
+import org.folio.rest.jaxrs.model.FincSelectFilterToCollections;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ConfigMetadataCollectionsWithFiltersIT extends ApiTestBase {
+
+  static final String FILTERS_COLLECTIONS_ENDPOINT =
+      FINC_CONFIG_FILTERS_ENDPOINT + "/%s/collections";
+  static final String INCLUDE_FILTERED_BY_FALSE = "?includeFilteredBy=false";
+  private static final String INCLUDE_FILTERED_BY_TRUE = "?includeFilteredBy=true";
+  private static final String COLLECTION1_ID = "cae1d25d-c92e-43a3-90b9-28fb0149b907";
+  private static final String COLLECTION2_ID = "68aebb7f-6325-44e8-bcdd-f528fff6dca5";
+
+  @BeforeAll
+  static void beforeAll() {
+    loadTestSamples();
+  }
+
+  private static void loadTestSamples() {
+    // Setup ISILs
+    loadIsilUbl();
+    loadIsilDiku();
+
+    // Create a Metadata Collection
+    postMetadataCollection(COLLECTION1_ID, "123");
+    postMetadataCollection(COLLECTION2_ID, "234");
+
+    // Create Filters for tenant UBL
+    postFilterWithFilesAndCollections(
+        "Filter 1 UBL",
+        WHITELIST,
+        List.of(
+            createFilterFile("ubl_file_content1", "ubl_file1.txt", TENANT_UBL),
+            createFilterFile("ubl_file_content2", "ubl_file2.txt", TENANT_UBL)),
+        List.of(COLLECTION1_ID),
+        TENANT_UBL);
+
+    postFilterWithFilesAndCollections(
+        "Filter 2 UBL", WHITELIST, null, List.of(COLLECTION1_ID), TENANT_UBL);
+
+    // Create Filters for tenant Diku
+    postFilterWithFilesAndCollections(
+        "Filter Diku",
+        BLACKLIST,
+        List.of(createFilterFile("diku_file_content1", "diku_file1.txt", TENANT_DIKU)),
+        List.of(COLLECTION1_ID),
+        TENANT_DIKU);
+  }
+
+  private static void postFilterWithFilesAndCollections(
+      String filterName,
+      FincSelectFilter.Type filterType,
+      List<FilterFile> filterFiles,
+      List<String> collections,
+      String tenantId) {
+    // Create Filter
+    FincSelectFilter filter =
+        new FincSelectFilter()
+            .withLabel(filterName)
+            .withId(UUID.randomUUID().toString())
+            .withType(filterType)
+            .withFilterFiles(filterFiles);
+    String filterId = post(FINC_SELECT_FILTERS_ENDPOINT, filter, tenantId);
+
+    // Connect Filter to Collections
+    FincSelectFilterToCollections filter2collections =
+        new FincSelectFilterToCollections().withId(filterId).withCollectionIds(collections);
+    put(FILTERS_COLLECTIONS_ENDPOINT.formatted(filterId), filter2collections, tenantId);
+  }
+
+  private static void postMetadataCollection(String id, String nameSuffix) {
+    FincConfigMetadataCollection metadataCollection =
+        new FincConfigMetadataCollection()
+            .withId(id)
+            .withCollectionId("collection-" + nameSuffix)
+            .withLabel("Metadata Collection Test " + nameSuffix)
+            .withUsageRestricted(FincConfigMetadataCollection.UsageRestricted.NO)
+            .withSolrMegaCollections(List.of("Solr Mega Collection Test"));
+    post(FINC_CONFIG_METADATA_COLLECTIONS_ENDPOINT, metadataCollection, MODULE_TENANT);
+  }
+
+  private static FilterFile createFilterFile(String content, String filename, String tenantId) {
+    String ublFile1Id = postFile(content, tenantId);
+    return new FilterFile()
+        .withId(UUID.randomUUID().toString())
+        .withLabel(filename)
+        .withFilename(filename)
+        .withFileId(ublFile1Id)
+        .withCriteria(filename + "-criteria");
+  }
+
+  private void assertFilteredBy(List<? extends FilteredBy> filteredBy) {
+    assertThat(filteredBy).hasSize(3);
+    assertThat(filteredBy)
+        .extracting(FilteredBy::getIsil)
+        .containsExactlyInAnyOrder("DE-15", "DE-15", "DIKU-01");
+    assertThat(filteredBy)
+        .flatExtracting(FilteredBy::getFilterFiles)
+        .extracting(FilterFile::getId)
+        .hasSize(3)
+        .allMatch(ObjectUtils::isNotEmpty);
+  }
+
+  @Test
+  void testGetCollectionsWithFilters() {
+    assertThat(
+            given()
+                .header(TENANT, MODULE_TENANT)
+                .get(FINC_CONFIG_METADATA_COLLECTIONS_ENDPOINT + INCLUDE_FILTERED_BY_TRUE)
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(FincConfigMetadataCollectionWithFiltersCollection.class)
+                .getFincConfigMetadataCollections()
+                .stream()
+                .map(FincConfigMetadataCollectionWithFilters::getFilteredBy)
+                .toList())
+        .hasSize(2)
+        .anyMatch(List::isEmpty)
+        .anySatisfy(this::assertFilteredBy);
+  }
+
+  @ParameterizedTest
+  @CsvSource({COLLECTION1_ID + ", true", COLLECTION2_ID + ", false"})
+  void testGetCollectionByIdWithFilters(String collectionId, boolean shouldContainElements) {
+    ThrowingConsumer<List<? extends FilteredBy>> assertFilteredBy =
+        shouldContainElements ? this::assertFilteredBy : List::isEmpty;
+    assertThat(
+            given()
+                .header(TENANT, MODULE_TENANT)
+                .get(
+                    FINC_CONFIG_METADATA_COLLECTIONS_ENDPOINT
+                        + "/"
+                        + collectionId
+                        + INCLUDE_FILTERED_BY_TRUE)
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(FincConfigMetadataCollectionWithFilters.class)
+                .getFilteredBy())
+        .satisfies(assertFilteredBy);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {INCLUDE_FILTERED_BY_FALSE, ""})
+  void testGetCollectionsWithoutFilters(String queryStr) {
+    // fails if the JSON response contains a "filteredBy" attribute due to
+    // additionalAttributes=false
+    assertThat(
+            given()
+                .header(TENANT, MODULE_TENANT)
+                .get(FINC_CONFIG_METADATA_COLLECTIONS_ENDPOINT + queryStr)
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(FincConfigMetadataCollections.class)
+                .getFincConfigMetadataCollections())
+        .hasSize(2);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {INCLUDE_FILTERED_BY_FALSE, ""})
+  void testGetCollectionByIdWithoutFilters(String queryStr) {
+    // fails if the JSON response contains a "filteredBy" attribute due to
+    // additionalAttributes=false
+    assertThat(
+            given()
+                .header(TENANT, MODULE_TENANT)
+                .get(FINC_CONFIG_METADATA_COLLECTIONS_ENDPOINT + "/" + COLLECTION1_ID + queryStr)
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(FincConfigMetadataCollection.class)
+                .getId())
+        .isEqualTo(COLLECTION1_ID);
+  }
+}

--- a/src/test/java/org/folio/finc/config/ConfigMetadataCollectionsWithFiltersIT.java
+++ b/src/test/java/org/folio/finc/config/ConfigMetadataCollectionsWithFiltersIT.java
@@ -9,7 +9,6 @@ import static org.folio.rest.utils.Constants.MODULE_TENANT;
 
 import java.util.List;
 import java.util.UUID;
-
 import org.apache.commons.lang3.ObjectUtils;
 import org.assertj.core.api.ThrowingConsumer;
 import org.folio.finc.ApiTestBase;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIFC-404

* Adds new query parameter `includeFilteredBy` to `/metadata-collections` and `/metadata-collections/{id}` endpoints
  * When set to `true`, it includes a `filteredBy` attribute in the JSON response, which lists filters associated with the metadata collection
* Adds a JUnit5 test to verify the correct functionality of the new feature
* Adds a db view for metadata collections with filters
* Adds a db index for performance on that view