### PR TITLE
[UIFC-404] Use `totalRecords` parameter when retrieving metadata collections

### DIFF
--- a/src/main/java/org/folio/rest/impl/FincConfigMetadataCollectionsAPI.java
+++ b/src/main/java/org/folio/rest/impl/FincConfigMetadataCollectionsAPI.java
@@ -51,6 +51,10 @@ public class FincConfigMetadataCollectionsAPI implements FincConfigMetadataColle
         : org.folio.rest.jaxrs.model.FincConfigMetadataCollections.class;
   }
 
+  private String determineTotalRecords(boolean includeFilteredBy, String totalRecords) {
+    return includeFilteredBy ? "none" : totalRecords;
+  }
+
   @Override
   @Validate
   public void getFincConfigMetadataCollections(
@@ -73,6 +77,7 @@ public class FincConfigMetadataCollectionsAPI implements FincConfigMetadataColle
         determineClass(includeFilteredBy),
         determineCollectionClass(includeFilteredBy),
         query,
+        determineTotalRecords(includeFilteredBy, totalRecords),
         offset,
         limit,
         okapiHeaders,


### PR DESCRIPTION
As an addition to https://folio-org.atlassian.net/browse/UIFC-404:

* Use `totalRecords` query param on `/finc-config/metadata-collections`
* Also override the query param to `totalRecords=none` when using the `includeFilteredBy` query param as RMB otherwise performs a very expensive count query