### PR TITLE
[UIFC-446] Return empty list when filter with no collection is requested.

### DIFF
--- a/src/main/java/org/folio/rest/impl/FincSelectFiltersAPI.java
+++ b/src/main/java/org/folio/rest/impl/FincSelectFiltersAPI.java
@@ -238,54 +238,61 @@ public class FincSelectFiltersAPI implements FincSelectFilters {
   @Override
   @Validate
   public void getFincSelectFiltersCollectionsById(
-    String id,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      String id,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
 
     String tenantId =
-      TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
+        TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
 
     isilDAO
-      .withIsilForTenant(tenantId, vertxContext)
-      .compose(isil ->
-        // First check if filter exists
-        selectFilterDAO.getById(id, isil, vertxContext)
-          .compose(filter -> {
-            if (filter == null) {
-              return Future.failedFuture("Filter not found");
-            }
-            // If filter exists, get its collections
-            return filterToCollectionsDAO.getByIdAndIsil(id, isil, vertxContext)
-              .map(collections -> collections != null ? collections :
-                new FincSelectFilterToCollections()
-                  .withCollectionIds(List.of())
-                  .withCollectionsCount(0));
-          }))
-      .onComplete(
-        reply -> {
-          if (reply.succeeded()) {
-            FincSelectFilterToCollections filterToCollections = reply.result();
-            filterToCollections.setIsil(null);
-            filterToCollections.setId(null);
-            asyncResultHandler.handle(
-              Future.succeededFuture(
-                GetFincSelectFiltersCollectionsByIdResponse
-                  .respond200WithApplicationJson(filterToCollections)));
-          } else {
-            if ("Filter not found".equals(reply.cause().getMessage())) {
-              asyncResultHandler.handle(
-                Future.succeededFuture(
-                  GetFincSelectFiltersCollectionsByIdResponse
-                    .respond404WithTextPlain("Not found")));
-            } else {
-              asyncResultHandler.handle(
-                Future.succeededFuture(
-                  GetFincSelectFiltersCollectionsByIdResponse
-                    .respond500WithTextPlain(MSG_INTERNAL_SERVER_ERROR)));
-            }
-          }
-        });
+        .withIsilForTenant(tenantId, vertxContext)
+        .compose(
+            isil ->
+                // First check if filter exists
+                selectFilterDAO
+                    .getById(id, isil, vertxContext)
+                    .compose(
+                        filter -> {
+                          if (filter == null) {
+                            return Future.failedFuture("Filter not found");
+                          }
+                          // If filter exists, get its collections
+                          return filterToCollectionsDAO
+                              .getByIdAndIsil(id, isil, vertxContext)
+                              .map(
+                                  collections ->
+                                      collections != null
+                                          ? collections
+                                          : new FincSelectFilterToCollections()
+                                              .withCollectionIds(List.of())
+                                              .withCollectionsCount(0));
+                        }))
+        .onComplete(
+            reply -> {
+              if (reply.succeeded()) {
+                FincSelectFilterToCollections filterToCollections = reply.result();
+                filterToCollections.setIsil(null);
+                filterToCollections.setId(null);
+                asyncResultHandler.handle(
+                    Future.succeededFuture(
+                        GetFincSelectFiltersCollectionsByIdResponse.respond200WithApplicationJson(
+                            filterToCollections)));
+              } else {
+                if ("Filter not found".equals(reply.cause().getMessage())) {
+                  asyncResultHandler.handle(
+                      Future.succeededFuture(
+                          GetFincSelectFiltersCollectionsByIdResponse.respond404WithTextPlain(
+                              "Not found")));
+                } else {
+                  asyncResultHandler.handle(
+                      Future.succeededFuture(
+                          GetFincSelectFiltersCollectionsByIdResponse.respond500WithTextPlain(
+                              MSG_INTERNAL_SERVER_ERROR)));
+                }
+              }
+            });
   }
 
   @Override

--- a/src/main/java/org/folio/rest/impl/FincSelectFiltersAPI.java
+++ b/src/main/java/org/folio/rest/impl/FincSelectFiltersAPI.java
@@ -238,40 +238,54 @@ public class FincSelectFiltersAPI implements FincSelectFilters {
   @Override
   @Validate
   public void getFincSelectFiltersCollectionsById(
-      String id,
-      Map<String, String> okapiHeaders,
-      Handler<AsyncResult<Response>> asyncResultHandler,
-      Context vertxContext) {
+    String id,
+    Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+
     String tenantId =
-        TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
+      TenantTool.calculateTenantId(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
 
     isilDAO
-        .withIsilForTenant(tenantId, vertxContext)
-        .compose(isil -> filterToCollectionsDAO.getByIdAndIsil(id, isil, vertxContext))
-        .onComplete(
-            reply -> {
-              if (reply.succeeded()) {
-                FincSelectFilterToCollections filterToCollections = reply.result();
-                if (filterToCollections != null) {
-                  filterToCollections.setIsil(null);
-                  filterToCollections.setId(null);
-                  asyncResultHandler.handle(
-                      Future.succeededFuture(
-                          GetFincSelectFiltersCollectionsByIdResponse.respond200WithApplicationJson(
-                              filterToCollections)));
-                } else {
-                  asyncResultHandler.handle(
-                      Future.succeededFuture(
-                          GetFincSelectFiltersCollectionsByIdResponse.respond404WithTextPlain(
-                              "Not found")));
-                }
-              } else {
-                asyncResultHandler.handle(
-                    Future.succeededFuture(
-                        GetFincSelectFiltersCollectionsByIdResponse.respond500WithTextPlain(
-                            MSG_INTERNAL_SERVER_ERROR)));
-              }
-            });
+      .withIsilForTenant(tenantId, vertxContext)
+      .compose(isil ->
+        // First check if filter exists
+        selectFilterDAO.getById(id, isil, vertxContext)
+          .compose(filter -> {
+            if (filter == null) {
+              return Future.failedFuture("Filter not found");
+            }
+            // If filter exists, get its collections
+            return filterToCollectionsDAO.getByIdAndIsil(id, isil, vertxContext)
+              .map(collections -> collections != null ? collections :
+                new FincSelectFilterToCollections()
+                  .withCollectionIds(List.of())
+                  .withCollectionsCount(0));
+          }))
+      .onComplete(
+        reply -> {
+          if (reply.succeeded()) {
+            FincSelectFilterToCollections filterToCollections = reply.result();
+            filterToCollections.setIsil(null);
+            filterToCollections.setId(null);
+            asyncResultHandler.handle(
+              Future.succeededFuture(
+                GetFincSelectFiltersCollectionsByIdResponse
+                  .respond200WithApplicationJson(filterToCollections)));
+          } else {
+            if ("Filter not found".equals(reply.cause().getMessage())) {
+              asyncResultHandler.handle(
+                Future.succeededFuture(
+                  GetFincSelectFiltersCollectionsByIdResponse
+                    .respond404WithTextPlain("Not found")));
+            } else {
+              asyncResultHandler.handle(
+                Future.succeededFuture(
+                  GetFincSelectFiltersCollectionsByIdResponse
+                    .respond500WithTextPlain(MSG_INTERNAL_SERVER_ERROR)));
+            }
+          }
+        });
   }
 
   @Override

--- a/src/test/java/org/folio/finc/select/FincSelectFiltersIT.java
+++ b/src/test/java/org/folio/finc/select/FincSelectFiltersIT.java
@@ -274,24 +274,24 @@ public class FincSelectFiltersIT extends ApiTestBase {
     filter1.setId(UUID.randomUUID().toString());
 
     given()
-      .body(Json.encode(filter1))
-      .header("X-Okapi-Tenant", TENANT_UBL)
-      .header("content-type", ContentType.JSON)
-      .header("accept", ContentType.JSON)
-      .post(FINC_SELECT_FILTERS_ENDPOINT)
-      .then()
-      .statusCode(201)
-      .body("id", equalTo(filter1.getId()))
-      .body("label", equalTo(filter1.getLabel()))
-      .body("type", equalTo(filter1.getType().value()));
+        .body(Json.encode(filter1))
+        .header("X-Okapi-Tenant", TENANT_UBL)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .post(FINC_SELECT_FILTERS_ENDPOINT)
+        .then()
+        .statusCode(201)
+        .body("id", equalTo(filter1.getId()))
+        .body("label", equalTo(filter1.getLabel()))
+        .body("type", equalTo(filter1.getType().value()));
 
     given()
-      .header("X-Okapi-Tenant", TENANT_UBL)
-      .header("content-type", ContentType.JSON)
-      .header("accept", ContentType.JSON)
-      .get(FINC_SELECT_FILTERS_ENDPOINT + "/" + filter1.getId() + "/collections")
-      .then()
-      .statusCode(200)
-      .body("collectionIds.size()", equalTo(0));
+        .header("X-Okapi-Tenant", TENANT_UBL)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .get(FINC_SELECT_FILTERS_ENDPOINT + "/" + filter1.getId() + "/collections")
+        .then()
+        .statusCode(200)
+        .body("collectionIds.size()", equalTo(0));
   }
 }

--- a/src/test/java/org/folio/finc/select/FincSelectFiltersIT.java
+++ b/src/test/java/org/folio/finc/select/FincSelectFiltersIT.java
@@ -271,8 +271,6 @@ public class FincSelectFiltersIT extends ApiTestBase {
 
   @Test
   public void checkThatWeReturnAnEmptyListAnd200IfFilterWithNoCollectionIsQueried() {
-    filter1.setId(UUID.randomUUID().toString());
-
     given()
         .body(Json.encode(filter1))
         .header("X-Okapi-Tenant", TENANT_UBL)
@@ -293,5 +291,19 @@ public class FincSelectFiltersIT extends ApiTestBase {
         .then()
         .statusCode(200)
         .body("collectionIds.size()", equalTo(0));
+
+    given()
+        .header("X-Okapi-Tenant", TENANT_UBL)
+        .delete(FINC_SELECT_FILTERS_ENDPOINT + "/" + filter1.getId())
+        .then()
+        .statusCode(204);
+
+    given()
+        .header("X-Okapi-Tenant", TENANT_UBL)
+        .header("content-type", ContentType.JSON)
+        .header("accept", ContentType.JSON)
+        .get(FINC_SELECT_FILTERS_ENDPOINT + "/" + filter1.getId() + "/collections")
+        .then()
+        .statusCode(404);
   }
 }

--- a/src/test/java/org/folio/finc/select/FincSelectFiltersIT.java
+++ b/src/test/java/org/folio/finc/select/FincSelectFiltersIT.java
@@ -268,4 +268,30 @@ public class FincSelectFiltersIT extends ApiTestBase {
         .then()
         .statusCode(400);
   }
+
+  @Test
+  public void checkThatWeReturnAnEmptyListAnd200IfFilterWithNoCollectionIsQueried() {
+    filter1.setId(UUID.randomUUID().toString());
+
+    given()
+      .body(Json.encode(filter1))
+      .header("X-Okapi-Tenant", TENANT_UBL)
+      .header("content-type", ContentType.JSON)
+      .header("accept", ContentType.JSON)
+      .post(FINC_SELECT_FILTERS_ENDPOINT)
+      .then()
+      .statusCode(201)
+      .body("id", equalTo(filter1.getId()))
+      .body("label", equalTo(filter1.getLabel()))
+      .body("type", equalTo(filter1.getType().value()));
+
+    given()
+      .header("X-Okapi-Tenant", TENANT_UBL)
+      .header("content-type", ContentType.JSON)
+      .header("accept", ContentType.JSON)
+      .get(FINC_SELECT_FILTERS_ENDPOINT + "/" + filter1.getId() + "/collections")
+      .then()
+      .statusCode(200)
+      .body("collectionIds.size()", equalTo(0));
+  }
 }


### PR DESCRIPTION
This is intended to resolve the following bug: https://folio-org.atlassian.net/browse/UIFC-446

https://s3.amazonaws.com/foliodocs/api/mod-finc-config/r/fincSelectFilters.html#finc_select_filters__id__collections_get now returns an empty collection list and a status code 200, instead of a Not Found Error.