### PR TITLE
[UIFC-481] Add Memory to HostConfig in ModuleDescriptor template

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -892,6 +892,7 @@
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {
       "HostConfig": {
+        "Memory": 357913941,
         "PortBindings": {
           "8081/tcp": [
             {


### PR DESCRIPTION
The GA workflow docker publish step runs `generate_dockerhub_description.py`, which expects a `Memory` key in `ModuleDescriptor.json`'s `launchDescriptor.dockerArgs.HostConfig`, causing a `KeyError` when absent.